### PR TITLE
bump up version amazon plugin to 1.11.2 for 6.1.4 release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>amazon-s3-plugins</artifactId>
-  <version>1.11.1</version>
+  <version>1.11.2</version>
   <description>Plugins for Amazon S3</description>
   <url>https://github.com/data-integrations/amazon-s3-plugins</url>
 


### PR DESCRIPTION
bump up version amazon plugin to 1.11.2 for 6.1.4 release.