### PR TITLE
[CDAP-18876] Change error text when Access ID and Key are not provided

### DIFF
--- a/src/main/java/io/cdap/plugin/aws/s3/connector/S3Connector.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/connector/S3Connector.java
@@ -283,7 +283,7 @@ public class S3Connector extends AbstractFileConnector<S3ConnectorConfig> {
     }
 
     if (config.getAccessID() == null || config.getAccessKey() == null) {
-      throw new IllegalArgumentException("Access key and secret key are not provided");
+      throw new IllegalArgumentException("Access ID and Access Key are not provided");
     }
 
     AWSCredentials creds;


### PR DESCRIPTION
# [CDAP-18876] Change error text when Access ID and Key are not provided

## Description
Change the error message from "Failed to explore connection. Error: 'Access key and secret key are not provided'" to "Failed to explore connection. Error: 'Access ID and Access Key are not provided'"

## Links
[CDAP-18876](https://cdap.atlassian.net/browse/CDAP-18876)

## Screenshots
![image](https://user-images.githubusercontent.com/98125204/158887073-e80be0ad-cc91-43b5-97a4-426c1c4e5bc8.png)
