### PR TITLE
CDAP-18878 fix s3n deprecation on spark3

### DIFF
--- a/src/main/java/io/cdap/plugin/aws/s3/common/S3Constants.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/common/S3Constants.java
@@ -25,12 +25,13 @@ public class S3Constants {
   public static final String S3A_SECRET_KEY = "fs.s3a.secret.key";
   public static final String S3A_SESSION_TOKEN = "fs.s3a.session.token";
   public static final String S3A_CREDENTIAL_PROVIDERS = "fs.s3a.aws.credentials.provider";
-  public static final String S3A_TEMP_CREDENTIAL_PROVIDERS =
-      "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider";
-  public static final String S3A_SIMPLE_CREDENTIAL_PROVIDERS =
-      "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider";
+  public static final String S3A_TEMP_CREDENTIAL_PROVIDERS = "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider";
+  public static final String S3A_SIMPLE_CREDENTIAL_PROVIDERS = "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider";
   public static final String S3A_ENCRYPTION = "fs.s3a.server-side-encryption-algorithm";
   public static final String S3N_ACCESS_KEY = "fs.s3n.awsAccessKeyId";
   public static final String S3N_SECRET_KEY = "fs.s3n.awsSecretAccessKey";
   public static final String S3N_ENCRYPTION = "fs.s3n.server-side-encryption-algorithm";
+
+  // option to continue using s3n if an s3n path is provided
+  public static final String USE_S3N = "keep.s3n.scheme";
 }

--- a/src/main/java/io/cdap/plugin/aws/s3/common/S3Path.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/common/S3Path.java
@@ -22,11 +22,13 @@ import java.util.regex.Pattern;
 
 /**
  * A path on S3. Contains information about the bucket and file name (if applicable).
- * A path is of the form s3n://bucket/name.
+ * A path is of the form s3a://bucket/name or s3n://bucket/name.
+ * All s3n path will be converted to s3a path
  */
 public class S3Path {
   public static final String ROOT_DIR = "/";
-  public static final String SCHEME = "s3n://";
+  public static final String SCHEME = "s3a://";
+  public static final String OLD_SCHEME = "s3n://";
   private final String fullPath;
   private final String bucket;
   private final String name;
@@ -91,7 +93,7 @@ public class S3Path {
 
     if (path.startsWith(ROOT_DIR)) {
       path = path.substring(1);
-    } else if (path.startsWith(SCHEME)) {
+    } else if (path.startsWith(SCHEME) || path.startsWith(OLD_SCHEME)) {
       path = path.substring(SCHEME.length());
     }
 

--- a/src/main/java/io/cdap/plugin/aws/s3/connector/S3Connector.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/connector/S3Connector.java
@@ -120,7 +120,7 @@ public class S3Connector extends AbstractFileConnector<S3ConnectorConfig> {
     if (isRoot(path)) {
       return S3Path.SCHEME;
     }
-    return S3Path.from(path).getFullPath().toString();
+    return S3Path.from(path).getFullPath();
   }
 
   @Override
@@ -130,8 +130,8 @@ public class S3Connector extends AbstractFileConnector<S3ConnectorConfig> {
       return properties;
     }
 
-    properties.put(S3Constants.S3N_ACCESS_KEY, config.getAccessID());
-    properties.put(S3Constants.S3N_SECRET_KEY, config.getAccessKey());
+    properties.put(S3Constants.S3A_ACCESS_KEY, config.getAccessID());
+    properties.put(S3Constants.S3A_SECRET_KEY, config.getAccessKey());
     return properties;
   }
 

--- a/src/test/java/io/cdap/plugin/aws/s3/common/S3PathTest.java
+++ b/src/test/java/io/cdap/plugin/aws/s3/common/S3PathTest.java
@@ -29,22 +29,24 @@ public class S3PathTest {
   @Test
   public void testGetPath() {
     S3Path s3Path = S3Path.from("s3n://my-bucket/part1");
-    Assert.assertEquals("s3n://my-bucket/part1", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/part1", s3Path.getFullPath());
     s3Path = S3Path.from("my-bucket/part1");
-    Assert.assertEquals("s3n://my-bucket/part1", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/part1", s3Path.getFullPath());
     s3Path = S3Path.from("/my-bucket/part1");
-    Assert.assertEquals("s3n://my-bucket/part1", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/part1", s3Path.getFullPath());
 
     s3Path = S3Path.from("s3n://my-bucket/part1/part2");
-    Assert.assertEquals("s3n://my-bucket/part1/part2", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/part1/part2", s3Path.getFullPath());
     s3Path = S3Path.from("my-bucket/part1/part2");
-    Assert.assertEquals("s3n://my-bucket/part1/part2", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/part1/part2", s3Path.getFullPath());
     s3Path = S3Path.from("/my-bucket/part1/part2");
-    Assert.assertEquals("s3n://my-bucket/part1/part2", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/part1/part2", s3Path.getFullPath());
     s3Path = S3Path.from("s3n://my-bucket/part1/hello world");
-    Assert.assertEquals("s3n://my-bucket/part1/hello world", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/part1/hello world", s3Path.getFullPath());
     s3Path = S3Path.from("s3n://my-bucket/hello world 1/hello world 2");
-    Assert.assertEquals("s3n://my-bucket/hello world 1/hello world 2", s3Path.getFullPath());
+    Assert.assertEquals("s3a://my-bucket/hello world 1/hello world 2", s3Path.getFullPath());
+    s3Path = S3Path.from("s3a://my-bucket/hello world 1/hello world 2");
+    Assert.assertEquals("s3a://my-bucket/hello world 1/hello world 2", s3Path.getFullPath());
 
     assertFailure(() -> S3Path.from(""));
     assertFailure(() -> S3Path.from("s3n:/abc/"));


### PR DESCRIPTION
Default to use s3a even if a s3n is provided. If customer wants to stick to s3n, they can use the runtime arguments to not convert the path to s3a