### PR TITLE
Exclude vulnerable and unused hive-jdbc transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,10 @@
           <groupId>org.apache.hive</groupId>
           <artifactId>hive-exec</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-jdbc</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Transitive dependency `org.apache.hive:hive-jdbc:jar:1.2.1` (via `io.cdap.cdap:hydrator-test` ->  `io.cdap.cdap:cdap-explore`) has a vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-1282). 

The PR excludes the dependency as it's not actually used.