### PR TITLE
[CDAP-19512] Fix security vulnerability in log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,10 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>


### PR DESCRIPTION
Excluding `log4j:1.2.17` from
- `org.apache.hadoop:hadoop-mapreduce-client-core:2.8.0`

Fixes vulnerability
- [CVE-2019-17571](https://nvd.nist.gov/vuln/detail/CVE-2019-17571)

Verified using `mvn dependency:tree`.