### PR TITLE
[PLUGIN-1454] Fix security vulnerabilities due to hadoop-common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <cdap.plugin.version>2.11.0-SNAPSHOT</cdap.plugin.version>
     <data.pipeline.parent>system:cdap-data-pipeline[6.8.0-SNAPSHOT, 7.0.0-SNAPSHOT)</data.pipeline.parent>
     <data.stream.parent>system:cdap-data-streams[6.8.0-SNAPSHOT, 7.0.0-SNAPSHOT)</data.stream.parent>
-    <hadoop.version>2.8.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <aws.sdk.version>1.11.133</aws.sdk.version>
     <main.basedir>${project.basedir}</main.basedir>
   </properties>


### PR DESCRIPTION
### Change Description

Fixed security vulnerabilities:
* [CVE-2022-25168](https://nvd.nist.gov/vuln/detail/CVE-2022-25168)

For dependencies:
* hadoop-common:2.8.0

Changes:
* Upgraded `hadoop-common` dependency version to `2.10.2`

### Verification
* Verified version override using `mvn dependency:tree`
* Created snapshot artifacts and deployed them