### PR TITLE
Vulnerability fix : Exclude the transitive dependency org.apache.ivy:ivy from hydrator-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.ivy</groupId>
+          <artifactId>ivy</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Excluded the ivy dependency as affected versions of this package are vulnerable to Directory Traversal in the 'IvyPatternHelper' class.

[INFO] io.cdap.plugin:amazon-s3-plugins:jar:1.19.0-SNAPSHOT
[INFO] \- io.cdap.cdap:hydrator-test:jar:6.9.0-SNAPSHOT:provided
[INFO]    \- io.cdap.cdap:cdap-unit-test:jar:6.9.0-SNAPSHOT:provided
[INFO]       \- io.cdap.cdap:cdap-spark-core2_2.11:jar:6.9.0-SNAPSHOT:provided
[INFO]          \- org.apache.spark:spark-core_2.11:jar:2.1.3:provided
[INFO]             \- org.apache.ivy:ivy:jar:2.4.0:provided

