### PR TITLE
[CDAP-20238] Remove Spark2 references and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
       <version>${cdap.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
As part of cdapio/cdap/pull/14797, the spark2 modules and references have been removed. Similar references in this repo need to be done and subsequent dependencies need to be updated.