### PR TITLE
[PLUGIN-1683] Upgrade aws-java-sdk-s3 to 1.12.522, maven-bundle-plugin 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,12 @@
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>${commons.logging.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>    
     </dependency>
     <!--    Conflict arose from hadoop-common.
     Added version 4.5.14 to resolve conflicts.-->

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.cdap.plugin</groupId>
@@ -251,11 +251,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!--    Conflict arose from hadoop-mapreduce-client-core.
+    Added version 1.1.3 to resolve conflicts.-->
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>${commons.logging.version}</version>
     </dependency>
+    <!--    Conflict arose from hadoop-common.
+    Added version 4.5.14 to resolve conflicts.-->
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <data.stream.parent>system:cdap-data-streams[6.8.0, 7.0.0-SNAPSHOT)</data.stream.parent>
     <hadoop.version>2.10.2</hadoop.version>
     <aws.sdk.version>1.12.552</aws.sdk.version>
-    <commons.logging.version>1.1.1</commons.logging.version>
+    <commons.logging.version>1.1.3</commons.logging.version>
     <httpclient.version>4.5.14</httpclient.version>
     <main.basedir>${project.basedir}</main.basedir>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,9 @@
     <data.pipeline.parent>system:cdap-data-pipeline[6.8.0, 7.0.0-SNAPSHOT)</data.pipeline.parent>
     <data.stream.parent>system:cdap-data-streams[6.8.0, 7.0.0-SNAPSHOT)</data.stream.parent>
     <hadoop.version>2.10.2</hadoop.version>
-    <aws.sdk.version>1.11.133</aws.sdk.version>
+    <aws.sdk.version>1.12.552</aws.sdk.version>
+    <commons.logging.version>1.1.1</commons.logging.version>
+    <httpclient.version>4.5.14</httpclient.version>
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
 
@@ -250,15 +252,19 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${commons.logging.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>${aws.sdk.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 
@@ -278,7 +284,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.5.4</version>
+          <version>3.5.0</version>
           <extensions>true</extensions>
           <configuration>
             <instructions>


### PR DESCRIPTION
JIRA - [PLUGIN-1683](https://cdap.atlassian.net/browse/PLUGIN-1683)

### Changes Made:

* **AWS SDK Upgrade:** Upgraded the AWS SDK (aws-java-sdk-s3) from version 1.11.133 to 1.12.522

* **Maven Bundle Plugin Upgrade:** Upgraded the Maven Bundle Plugin from version 2.5.4 to 3.5.0 as the build failed due to aws-java-sdk-s3 upgrade.

* **Jackson-Databind Exclusion:** Removed the exclusion of Jackson-Databind, previously introduced in [PR](https://github.com/data-integrations/amazon-s3-plugins/pull/141), as the latest version no longer exhibits any vulnerabilities.

* **Explicit Transitive Dependencies:**
  * **commons-logging:**
    - Added version 1.1.1 to resolve conflicts.
    - Conflict arose from hadoop-mapreduce-client-core.

  * **httpclient:**
    - Added version 4.5.14 to resolve conflicts.
    - Conflict arose from hadoop-common.

### Verification

* E2E tested by creating S3 connection.
* Verified version override using `mvn dependency:tree`.


[PLUGIN-1683]: https://cdap.atlassian.net/browse/PLUGIN-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ