### PR TITLE
Update scope of hydrator-test to resolve vulnerabilities coming in from transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       <groupId>io.cdap.cdap</groupId>
       <artifactId>hydrator-test</artifactId>
       <version>${cdap.version}</version>
-      <scope>provided</scope>
+      <scope>test</scope>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
context: `org.apache.ivy:ivy: 2.4.0` has [CVE-2022-37866](https://nvd.nist.gov/vuln/detail/CVE-2022-37866) coming from transitive dependency in `hydrator-test` which is only used in unit tests. 

`mvn dependency:tree` after fix:

```
+- com.fasterxml.jackson.module:jackson-module-scala_2.12:jar:2.10.0:test
[INFO] |     |  |  |  \- com.fasterxml.jackson.module:jackson-module-paranamer:jar:2.10.0:test
[INFO] |     |  |  +- org.apache.ivy:ivy:jar:2.4.0:test
[INFO] |     |  |  +- oro:oro:jar:2.0.8:test
[INFO] |     |  |  +- net.razorvine:pyrolite:jar:4.30:test
[INFO] |     |  |  +- net.sf.py4j:py4j:jar:0.10.9:test
```