### PR TITLE
[PLUGIN-1742] Added S3EmptyInputFormat

### DIFF
--- a/src/main/java/io/cdap/plugin/aws/s3/common/S3EmptyInputFormat.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/common/S3EmptyInputFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.plugin.aws.s3.common;
+
+import io.cdap.plugin.format.input.AbstractEmptyInputFormat;
+
+
+/**
+ * An InputFormat that returns no data.
+ * @param <K> the type of key
+ * @param <V> the type of value
+ */
+public class S3EmptyInputFormat<K, V> extends AbstractEmptyInputFormat<K, V> {
+  // no-op
+}

--- a/src/main/java/io/cdap/plugin/aws/s3/source/S3BatchSource.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/source/S3BatchSource.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.plugin.aws.s3.common.S3ConnectorConfig;
 import io.cdap.plugin.aws.s3.common.S3Constants;
+import io.cdap.plugin.aws.s3.common.S3EmptyInputFormat;
 import io.cdap.plugin.aws.s3.common.S3Path;
 import io.cdap.plugin.aws.s3.connector.S3Connector;
 import io.cdap.plugin.common.Asset;
@@ -68,6 +69,11 @@ public class S3BatchSource extends AbstractFileSource<S3BatchSource.S3BatchConfi
   public S3BatchSource(S3BatchConfig config) {
     super(config);
     this.config = config;
+  }
+
+  @Override
+  protected String getEmptyInputFormatClassName() {
+    return S3EmptyInputFormat.class.getName();
   }
 
   @Override


### PR DESCRIPTION
## Added S3EmptyInputFormat

Jira : [PLUGIN-1742](https://cdap.atlassian.net/browse/PLUGIN-1742)

### Description

- Plugins that extend from AbstractFileSource ([link](https://github.com/cdapio/hydrator-plugins/blob/923e603df5b464821ed25c9f88ab9ecee9f0255d/format-common/src/main/java/io/cdap/plugin/format/plugin/AbstractFileSource.java#L206)) which are outside of the Core Plugins module will not correctly export the EmptyInputFormat !

- This PR implements a S3EmptyInputFormat that will be used when file is empty !

### UI Field

- No Changes made to widget json.

### Docs

- No Changes made to docs.

### Code change

- Added `S3EmptyInputFormat.java`
- Modified `S3BatchSource.java`

### Unit Tests

- No Changes made to unit tests.


[PLUGIN-1742]: https://cdap.atlassian.net/browse/PLUGIN-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ