### PR TITLE
CDAP-21027 : Upgrading hadoop version to 3.3.6 and plugin version and CDAP version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.9.0</cdap.version>
-    <cdap.plugin.version>2.11.0</cdap.plugin.version>
-    <data.pipeline.parent>system:cdap-data-pipeline[6.8.0, 7.0.0-SNAPSHOT)</data.pipeline.parent>
-    <data.stream.parent>system:cdap-data-streams[6.8.0, 7.0.0-SNAPSHOT)</data.stream.parent>
-    <hadoop.version>2.10.2</hadoop.version>
+    <cdap.version>6.11.0-SNAPSHOT</cdap.version>
+    <cdap.plugin.version>2.13.0-SNAPSHOT</cdap.plugin.version>
+    <data.pipeline.parent>system:cdap-data-pipeline[6.11.0-SNAPSHOT, 7.0.0-SNAPSHOT)</data.pipeline.parent>
+    <data.stream.parent>system:cdap-data-streams[6.11.0-SNAPSHOT, 7.0.0-SNAPSHOT)</data.stream.parent>
+    <hadoop.version>3.3.6</hadoop.version>
     <aws.sdk.version>1.12.552</aws.sdk.version>
     <commons.logging.version>1.1.3</commons.logging.version>
     <httpclient.version>4.5.14</httpclient.version>


### PR DESCRIPTION
Testing from a test S3 bucket using build image from. 
- https://github.com/cdapio/cdap/pull/15648
- https://github.com/cdapio/hydrator-plugins/pull/1871 