### PR TITLE
[🍒][Plugin-1730] Adding XLS UI elements for S3 source

### DIFF
--- a/docs/S3-batchsource.md
+++ b/docs/S3-batchsource.md
@@ -19,14 +19,27 @@ the credentials does not need to be provided.
 **Path:** Path to read from. For example, s3a://<bucket>/path/to/input
 
 **Format:** Format of the data to read.
-The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', or 'tsv'.
+The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', 'tsv' or 'xls'.
 If the format is 'blob', every input file will be read into a separate record.
 The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
 If the format is 'text', the schema must contain a field named 'body' of type 'string'.
 
+**Sample Size:** The maximum number of rows that will get investigated for automatic data type detection.
+The default value is 1000. This is only used when the format is 'xls'.
+
+**Override:** A list of columns with the corresponding data types for whom the automatic data type detection gets
+skipped. This is only used when the format is 'xls'.
+
+**Terminate Reading After Empty Row:** Specify whether to stop reading after encountering the first empty row. Defaults to false. When false the reader will read all rows in the sheet. This is only used when the format is 'xls'.
+
+**Select Sheet Using:** Select the sheet by name or number. Default is 'Sheet Number'. This is only used when the format is 'xls'.
+
+**Sheet Value:** The name/number of the sheet to read from. If not specified, the first sheet will be read.
+Sheet Numbers are 0 based, ie first sheet is 0. This is only used when the format is 'xls'.
+
 **Delimiter:** Delimiter to use when the format is 'delimited'. This will be ignored for other formats.
 
-**Use First Row as Header:** Whether to use first row as header. Supported formats are 'text', 'csv', 'tsv', 'delimited'.
+**Use First Row as Header:** Whether to use first row as header. Supported formats are 'text', 'csv', 'tsv', 'delimited', 'xls'.
 
 **Authentication Method:** Authentication method to access S3. The default value is Access Credentials.
 IAM can only be used if the plugin is run in an AWS environment, such as on EMR.

--- a/src/main/java/io/cdap/plugin/aws/s3/source/S3BatchSource.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/source/S3BatchSource.java
@@ -141,6 +141,9 @@ public class S3BatchSource extends AbstractFileSource<S3BatchSource.S3BatchConfi
     public static final String NAME_PATH = "path";
     private static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
     private static final String NAME_DELIMITER = "delimiter";
+    private static final String NAME_SHEET = "sheet";
+    private static final String NAME_SHEET_VALUE = "sheetValue";
+    private static final String NAME_TERMINATE_IF_EMPTY_ROW = "terminateIfEmptyRow";
 
     private static final Gson GSON = new Gson();
     private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
@@ -173,6 +176,36 @@ public class S3BatchSource extends AbstractFileSource<S3BatchSource.S3BatchConfi
       "credentials are incorrect. When true, the accuracy of the credentials will be evaluated and validation will " +
       "fail, if credentials are incorrect. The default value is false.")
     private Boolean verifyCredentials;
+
+    @Macro
+    @Nullable
+    @Description("The maximum number of rows that will get investigated for automatic data type detection.")
+    private Long sampleSize;
+
+    @Macro
+    @Nullable
+    @Description("A list of columns with the corresponding data types for whom the automatic data type detection gets" +
+            " skipped.")
+    private String override;
+
+    @Name(NAME_SHEET)
+    @Macro
+    @Nullable
+    @Description("Select the sheet by name or number. Default is 'Sheet Number'.")
+    private String sheet;
+
+    @Name(NAME_SHEET_VALUE)
+    @Macro
+    @Nullable
+    @Description("The name/number of the sheet to read from. If not specified, the first sheet will be read." +
+            "Sheet Numbers are 0 based, ie first sheet is 0.")
+    private String sheetValue;
+
+    @Name(NAME_TERMINATE_IF_EMPTY_ROW)
+    @Macro
+    @Nullable
+    @Description("Specify whether to stop reading after encountering the first empty row. Defaults to false.")
+    private String terminateIfEmptyRow;
 
     private S3BatchConfig(String path, @Nullable S3ConnectorConfig connection, String fileSystemProperties,
                           Boolean verifyCredentials) {

--- a/widgets/S3-batchsource.json
+++ b/widgets/S3-batchsource.json
@@ -120,7 +120,8 @@
               "json",
               "parquet",
               "text",
-              "tsv"
+              "tsv",
+              "xls"
             ],
             "default": "text"
           },
@@ -133,6 +134,36 @@
             ],
             "missing-required-fields-message": "Please provide path field",
             "plugin-method": "getSchema"
+          }
+        },
+        {
+          "widget-type": "number",
+          "label": "Sample Size",
+          "name": "sampleSize",
+          "widget-attributes": {
+            "default": "1000",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Override",
+          "name": "override",
+          "widget-attributes": {
+            "key-placeholder": "Field Name",
+            "value-placeholder": "Data Type",
+            "dropdownOptions": [
+              "boolean",
+              "bytes",
+              "double",
+              "float",
+              "int",
+              "long",
+              "string",
+              "date",
+              "time",
+              "timestamp"
+            ]
           }
         },
         {
@@ -173,6 +204,42 @@
               "value": "false",
               "label": "False"
             }
+          }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Terminate Reading After Empty Row",
+          "name": "terminateIfEmptyRow",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Select Sheet Using",
+          "name": "sheet",
+          "widget-attributes": {
+            "values": [
+              "Sheet Name",
+              "Sheet Number"
+            ],
+            "default": "Sheet Number"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Sheet Value",
+          "name": "sheetValue",
+          "widget-attributes": {
+            "default": "0"
           }
         }
       ]
@@ -674,11 +741,44 @@
     {
       "name": "skipHeader",
       "condition": {
-        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv'"
+        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv' || format == 'xls'"
       },
       "show": [
         {
           "name": "skipHeader"
+        }
+      ]
+    },
+    {
+      "name": "sheet",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheet"
+        }
+      ]
+    },
+    {
+      "name": "sheetValue",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheetValue"
+        }
+      ]
+    },
+    {
+      "name": "terminateIfEmptyRow",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "terminateIfEmptyRow"
         }
       ]
     }


### PR DESCRIPTION
[🍒]

🍒 [cherrypick] [6.10]

### Commits :
 - 08a6d6328aa711f4e36ed74b37964db208837b9b

### PR:
 - #200 [ Reviewer @itsankit-google ]
 
---

## Adding XLS UI elements for S3 source

Jira : [Plugin-1730](https://cdap.atlassian.net/browse/PLUGIN-1730)

### Description
This PR adds UI element required for XLS Support in `S3 Source`.
Ref : XLS Support PR https://github.com/cdapio/hydrator-plugins/pull/1835

### Added Fields 
- Sample Size
- Override
- Terminate If Empty Row
- Select Sheet Using
- Sheet Value

A filter is used to show XLS specific values  `Terminate If Empty Row` , `Select Sheet Using`, `Sheet Value` only when format `XLS` is selected.

### Preview
<img width="950" alt="image" src="https://github.com/user-attachments/assets/2ee04d67-c1f6-4dd8-abaa-8e3f9612c7c3" />

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/03256663-a0f4-496b-abc1-8331fa41be3d" />


## Sanity Tests 

### Data Used
[xlsx_bench.xlsx](https://github.com/user-attachments/files/20080031/xlsx_bench.xlsx)

- A xlsx file with 3 sheets
- Sheet 1 (data with headers)
- Sheet 2 (data without headers)
- Sheet 3 (data with headers and an empty line)

#### "Sheet1" [index 0]
![image](https://github.com/user-attachments/assets/2b6fa143-7f10-49ad-9b33-8fd1db80bc2f)

#### "Sheet2" [index 1]
![image](https://github.com/user-attachments/assets/7cff67c1-e6c5-4de1-8a40-71ffe1252b66)

#### "Sheet3" [index 2]
![image](https://github.com/user-attachments/assets/24da1b90-0f88-4c84-ba46-a316fcb551ae)

---

## Test 1 [Read a sheet with headers]

> We will be testing can the plugin read a sheet with headers defined, also skip the first row while reading data.

- Config
  - Turn on "Use First Row as Header" 
![image](https://github.com/user-attachments/assets/a46ed27f-1a58-42a5-9262-0d24f061ab89)

- Deploy
![image](https://github.com/user-attachments/assets/0b696b67-b970-47c6-b37f-5c38e01ada9f)

- Output
![image](https://github.com/user-attachments/assets/baa0e02b-cf0d-41db-85ab-3b7152c8df1c)



## Test 2 [Read a sheet using it's name + Read a sheet other than the 1st + Read a sheet without headers]

> We will be testing can the plugin read a sheet using the sheet's name.
> We will be testing if the plugin can read any sheet other than the first one, we will also be testing if the plugin can read sheet without a header.

- Config
  - Set "Select Sheet Using" to "Sheet Name"
  - Add the sheet name
![image](https://github.com/user-attachments/assets/6e35639a-d61f-4d4d-a2e0-c85a13f95558)

- Deploy
![image](https://github.com/user-attachments/assets/9ac26155-e385-40c5-ab89-00ede2b86214)


- Output
![image](https://github.com/user-attachments/assets/231541b2-014f-43ea-b3d0-e79705b0a740)


## Test 3 [Do not stop reading when a row is missing]

> We will be testing if the plugin can keep reading if an empty row is encountered.

- Config
  - Turn off "Terminate Reading After Empty Row" 
![image](https://github.com/user-attachments/assets/62e98efb-bf9c-456c-b24c-2138c9899948)


- Deploy
![image](https://github.com/user-attachments/assets/e76fc0f2-4850-43c0-a085-3956ba3dff47)


- Output
![image](https://github.com/user-attachments/assets/92596fe6-6a4b-4e8e-b51f-23e5f073160f)


## Test 4 [Stop reading when a row is missing]

> We will be testing if the plugin can stop reading if an empty row is encountered.

- Config
    - Turn on "Terminate Reading After Empty Row"
![image](https://github.com/user-attachments/assets/06b3088b-4d72-4649-aa7d-968b8205f474)


- Deploy
![image](https://github.com/user-attachments/assets/959832ae-690d-4ca7-a23f-9cb14a69f64c)


- Output
![image](https://github.com/user-attachments/assets/8a8771c2-725c-40de-86db-de702e50a006)

